### PR TITLE
feat: restrict loadFn to Observable return type

### DIFF
--- a/projects/ngx-data-loader/src/lib/ngx-data-loader.component.spec.ts
+++ b/projects/ngx-data-loader/src/lib/ngx-data-loader.component.spec.ts
@@ -1,6 +1,6 @@
-import { LoadingStateTemplatePipe } from './loading-state-template.pipe';
 import {
   ComponentFixture,
+  discardPeriodicTasks,
   fakeAsync,
   flush,
   TestBed,
@@ -9,8 +9,9 @@ import {
 import { of, throwError, timer } from 'rxjs';
 import { DataComponent } from './data/data.component';
 import { ErrorComponent } from './error/error.component';
-import { NgxDataLoaderComponent } from './ngx-data-loader.component';
+import { LoadingStateTemplatePipe } from './loading-state-template.pipe';
 import { LoadingComponent } from './loading/loading.component';
+import { NgxDataLoaderComponent } from './ngx-data-loader.component';
 
 describe('NgxDataLoaderComponent', () => {
   let component: NgxDataLoaderComponent;
@@ -56,7 +57,7 @@ describe('NgxDataLoaderComponent', () => {
     });
 
     it('should render only a loading component when loading first time', () => {
-      component.loadFn = () => new Promise(() => ({}));
+      component.loadFn = () => of({});
       component.reload();
       expect(getSkeletonEl()).toBeTruthy();
       expect(getDataEl()).toBeNull();
@@ -88,7 +89,7 @@ describe('NgxDataLoaderComponent', () => {
       component.showStaleData = true;
       component.reload();
       tick();
-      component.loadFn = () => new Promise(() => ({}));
+      component.loadFn = () => of({});
       component.reload();
       tick();
       fixture.detectChanges();
@@ -102,13 +103,15 @@ describe('NgxDataLoaderComponent', () => {
       component.showStaleData = false;
       component.reload();
       tick();
-      component.loadFn = () => new Promise(() => ({}));
+      component.loadFn = () => timer(10);
       component.reload();
       tick();
       fixture.detectChanges();
       expect(getDataEl()).toBeNull();
       expect(getSkeletonEl()).toBeTruthy();
       expect(getErrorEl()).toBeNull();
+      flush();
+      discardPeriodicTasks();
     }));
 
     it('should render an error when loading does not complete before the timeout', fakeAsync(() => {

--- a/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
+++ b/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
@@ -53,7 +53,7 @@ export class NgxDataLoaderComponent<T = unknown> implements OnInit, OnChanges {
    * loadFn = () => this.http.get('https://example.com/api/data')
    */
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  @Input() loadFn!: (args?: any) => Observable<T> | Promise<T>;
+  @Input() loadFn!: (args?: any) => Observable<T>;
 
   /**
    * Arguments to pass to `loadFn`. Changes to this property will trigger a reload.
@@ -200,7 +200,7 @@ export class NgxDataLoaderComponent<T = unknown> implements OnInit, OnChanges {
 
   private getData() {
     this.loadAttemptStarted.emit();
-    return from(this.loadFn(this.loadFnArgs)).pipe(
+    return this.loadFn(this.loadFnArgs).pipe(
       map((data) => ({ data, loaded: true, loading: false })),
       tap((state) => this.dataLoaded.emit(state.data)),
       this.timeout ? timeout(this.timeout) : identity,

--- a/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
+++ b/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/core';
 import {
   concat,
-  from,
   identity,
   merge,
   Observable,


### PR DESCRIPTION
BREAKING CHANGE: the loadFn function now only accepts Observables as return type and no longer accepts Promises. This is a breaking change as it may affect existing code that relies on the previous behavior. The change was made to provide a more consistent and predictable API. If your code previously used a function that returned a Promise, you should wrap the promise with the rxjs from() operator to convert it into an Observable.