### PR TITLE
fix: cancel debounced trigger when overriding

### DIFF
--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -16,14 +16,14 @@ export class AppComponent {
   retries = 0;
   retryDelay = 1000;
   userId = '1';
-  debounceTime = 0;
+  debounceTime = 500;
 
   getUser = (userId: string) =>
     this.http
       .get<GetUsersResponse>('https://reqres.in/api/users/' + (userId || ''))
       .pipe(
         map((response) => response.data),
-        delay(1000)
+        delay(500)
       );
 
   constructor(private http: HttpClient) {}


### PR DESCRIPTION
Before this change, using setData or setError immediately after a normal load trigger would cause a conflict because the debounce timer on the load trigger was not canceled and caused data to be loaded as soon as the debounce time was finished, thereby overwriting the custom state set by setdata/error