### PR TITLE
Remove retry and timeout

### DIFF
--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -13,11 +13,8 @@
     [loadFn]="getUser"
     [loadFnArgs]="userId"
     [debounceTime]="debounceTime"
-    [retries]="retries"
-    [retryDelay]="retryDelay"
     [showStaleData]="showStaleData"
     [loadingTemplateDelay]="loadingTemplateDelay"
-    [timeout]="timeout"
     (loadingStateChange)="logChange($event)"
   >
     <ng-template #loaded let-data let-loading="loading">
@@ -45,11 +42,7 @@
     <input type="number" [(ngModel)]="debounceTime" id="debounceTime" />
     <small>Number of milliseconds to debounce reload triggers.</small>
   </div>
-  <div class="field">
-    <label for="timeout">timeout</label>
-    <input type="number" [(ngModel)]="timeout" id="timeout" />
-    <small>In milliseconds. </small>
-  </div>
+
   <div class="field">
     <label for="loadingTemplateDelay">loadingTemplateDelay</label>
     <input
@@ -62,22 +55,7 @@
       Default: <code>0</code></small
     >
   </div>
-  <div class="field">
-    <label for="retries">retries</label>
-    <input type="number" [(ngModel)]="retries" id="retries" />
-    <small
-      >How many retries of loadFn before showing error template. Default:
-      <code>0</code></small
-    >
-  </div>
-  <div class="field">
-    <label for="retryDelay">retryDelay</label>
-    <input type="number" [(ngModel)]="retryDelay" id="retryDelay" />
-    <small
-      >How many milliseconds to wait before each retry. Default:
-      <code>1000</code></small
-    >
-  </div>
+
   <div class="field">
     <div class="checkbox">
       <label for="showStaleData">showStaleData</label>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -11,10 +11,7 @@ import { GetUsersResponse, User } from './get-users-response.interface';
 })
 export class AppComponent {
   showStaleData = false;
-  timeout = 30000;
   loadingTemplateDelay = 0;
-  retries = 0;
-  retryDelay = 1000;
   userId = '1';
   debounceTime = 500;
 

--- a/projects/ngx-data-loader/README.md
+++ b/projects/ngx-data-loader/README.md
@@ -28,7 +28,6 @@ This simplifies data loading based on route parameters or input field values.
 - Automatic reload on input changes
 - Provides `reload` and `cancel` methods
 - Automatic cancellation of ongoing http requests on cancel/reload/destroy[^note]
-- Configurable retry and timeout
 
 ## Demo
 
@@ -167,11 +166,8 @@ export class AppComponent {
 | `@Input()`<br />`loadFnArgs?: any`             | Arguments to pass to `loadFn`. Changes to this property will trigger a reload.                                          |
 | `@Input()`<br />`initialData?: T`              | Data to be rendered on init. When set, `loadFn` will not be invoked on init. The loading state will be set to `loaded`. |
 | `@Input()`<br />`debounceTime: number`         | Number of milliseconds to debounce reloads.                                                                             |
-| `@Input()`<br />`retries: number`              | Number of times to retry loading the data. Default: `0`                                                                 |
-| `@Input()`<br />`retryDelay: number`           | Delay in milliseconds between retries. Default: `1000`                                                                  |
 | `@Input()`<br />`showStaleData: boolean`       | Whether to keep displaying previously loaded data while reloading. Default: `false`                                     |
 | `@Input()`<br />`loadingTemplateDelay: number` | Delay in milliseconds before showing the loading template. Default: `0`                                                 |
-| `@Input()`<br />`timeout?: number`             | Number of milliseconds to wait for `loadFn` to emit before throwing an error.                                           |
 
 ## Events
 

--- a/projects/ngx-data-loader/src/lib/ngx-data-loader.component.spec.ts
+++ b/projects/ngx-data-loader/src/lib/ngx-data-loader.component.spec.ts
@@ -112,24 +112,6 @@ describe('NgxDataLoaderComponent', () => {
       discardPeriodicTasks();
     }));
 
-    it('should render an error when loading does not complete before the timeout', fakeAsync(() => {
-      component.loadFn = () => timer(100);
-      component.timeout = 10;
-      component.reload();
-      tick(20);
-      fixture.detectChanges();
-      expect(getErrorEl()).toBeTruthy();
-    }));
-
-    it('should not render an error when loading completes before the timeout', fakeAsync(() => {
-      component.loadFn = () => timer(100);
-      component.timeout = 200;
-      component.reload();
-      tick(150);
-      fixture.detectChanges();
-      expect(getErrorEl()).toBeNull();
-    }));
-
     it('should not call loadFn after ngOnChanges when initialData input is set', () => {
       loadFnSpy = jasmine.createSpy();
       component.loadFn = loadFnSpy.and.returnValue(of(testData));

--- a/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
+++ b/projects/ngx-data-loader/src/lib/ngx-data-loader.component.ts
@@ -9,26 +9,16 @@ import {
   SimpleChanges,
   TemplateRef,
 } from '@angular/core';
-import {
-  Observable,
-  ReplaySubject,
-  Subject,
-  identity,
-  merge,
-  of,
-  timer,
-} from 'rxjs';
+import { Observable, ReplaySubject, Subject, merge, of, timer } from 'rxjs';
 import {
   catchError,
   finalize,
   map,
-  retry,
   scan,
   startWith,
   switchMap,
   takeUntil,
   tap,
-  timeout,
 } from 'rxjs/operators';
 import { LoadingState } from './loading-state.interface';
 
@@ -74,18 +64,6 @@ export class NgxDataLoaderComponent<T = unknown> implements OnInit, OnChanges {
   @Input() debounceTime = 0;
 
   /**
-   * Number of times to retry loading the data.
-   * @defaultValue `0`                                                                    |
-   */
-  @Input() retries = 0;
-
-  /**
-   * Delay in milliseconds between retries.
-   * @defaultValue `1000`
-   */
-  @Input() retryDelay = 1000;
-
-  /**
    * Whether to keep displaying previously loaded data while reloading.
    * @defaultValue `false`
    */
@@ -96,11 +74,6 @@ export class NgxDataLoaderComponent<T = unknown> implements OnInit, OnChanges {
    * @defaultValue `0`
    */
   @Input() loadingTemplateDelay = 0;
-
-  /**
-   * Number of milliseconds to wait for `loadFn` to emit before throwing an error.
-   */
-  @Input() timeout?: number;
 
   /**
    * Emits the data when loaded.
@@ -216,8 +189,6 @@ export class NgxDataLoaderComponent<T = unknown> implements OnInit, OnChanges {
     return this.loadFn(this.loadFnArgs).pipe(
       map((data) => ({ data, loaded: true, loading: false })),
       tap((state) => this.dataLoaded.emit(state.data)),
-      this.timeout ? timeout(this.timeout) : identity,
-      retry({ count: this.retries, delay: this.retryDelay }),
       catchError((error) => this.onError(error)),
       takeUntil(this.stop$),
       finalize(() => this.loadAttemptFinished.emit())


### PR DESCRIPTION
BREAKING: removing timeout and retry from the library as they are not core functionality and it is trivial to just add the retry() or timeout() operators in your loadFn.